### PR TITLE
Fix `composer.json` for use as a package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,8 @@
 {
+    "name": "kadamwhite/asset-loader",
+    "description": "Utilities to seamlessly consume Webpack-bundled assets in WordPress themes & plugins.",
+    "type": "wordpress-plugin",
+    "license": "GPL-2.0-or-later",
     "require-dev": {
         "humanmade/coding-standards": "^0.6.0"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a7ec29c49e8e912d446731b662e709c",
+    "content-hash": "0c059c4de9e69ae658c054c9dd1eaa9a",
     "packages": [],
     "packages-dev": [
         {
@@ -199,16 +199,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.4.1",
+            "version": "3.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "5b4333b4010625d29580eb4a41f1e53251be6baa"
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/5b4333b4010625d29580eb4a41f1e53251be6baa",
-                "reference": "5b4333b4010625d29580eb4a41f1e53251be6baa",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
+                "reference": "b8a7362af1cc1aadb5bd36c3defc4dda2cf5f0a8",
                 "shasum": ""
             },
             "require": {
@@ -246,7 +246,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2019-03-19T03:22:27+00:00"
+            "time": "2019-04-10T23:49:02+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",


### PR DESCRIPTION
`composer.json` was valid for simple usage with Composer but the missing fields
meant it was unable to be published/used as a package.

Fixes #7